### PR TITLE
Fix issue 12: make topological sort determinate

### DIFF
--- a/rdfwriter/utils.go
+++ b/rdfwriter/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/spdx/gordf/rdfloader/parser"
 	"github.com/spdx/gordf/uri"
+	"slices"
 	"strings"
 )
 
@@ -80,6 +81,16 @@ func getUniqueTriples(triples []*parser.Triple) []*parser.Triple {
 	for key := range set {
 		retList = append(retList, set[key])
 	}
+	slices.SortFunc(retList, func(a, b *parser.Triple) int {
+		c := strings.Compare(a.Subject.String(), b.Subject.String())
+		if c == 0 {
+			c = strings.Compare(a.Predicate.String(), b.Predicate.String())
+		}
+		if c == 0 {
+			c = strings.Compare(a.Object.String(), b.Predicate.String())
+		}
+		return c
+	})
 	return retList
 }
 

--- a/rdfwriter/utils_test.go
+++ b/rdfwriter/utils_test.go
@@ -136,6 +136,18 @@ func TestTopologicalSortTriples(t *testing.T) {
 		{Subject: nodes[0], Predicate: nodes[2], Object: nodes[3]},
 		{Subject: nodes[3], Predicate: nodes[4], Object: nodes[0]},
 	}
+	t.Logf("Got %d sortedTriples:", len(sortedTriples))
+	for k, v := range sortedTriples {
+			t.Logf("  sortedTriples[%v]=%s", k, v)
+	}
+	t.Logf("Want %d expectedTriples", len(expectedTriples))
+	for k, v := range expectedTriples {
+			t.Logf("  expectedTriples[%v]=%s", k, v)
+	}
+	t.Logf("Or %d anotherConfig", len(anotherConfig))
+	for k, v := range anotherConfig {
+			t.Logf("  anotherConfig[%v]=%s", k, v)
+	}
 	if !reflect.DeepEqual(sortedTriples, expectedTriples) && !reflect.DeepEqual(sortedTriples, anotherConfig) {
 		t.Errorf("sorted triples are not in correct order")
 	}


### PR DESCRIPTION
Sort the unique triples in GetNodeToTriples to make the order determinate.

Add logging to topological sort test to aid debugging.