### PR TITLE
Fix issue 15: synchronize data races in rdfloader

### DIFF
--- a/rdfloader/parser/node.go
+++ b/rdfloader/parser/node.go
@@ -1,6 +1,9 @@
 package parser
 
-import "fmt"
+import (
+	"fmt"
+	"sync/atomic"
+)
 
 type NODETYPE string
 
@@ -22,14 +25,18 @@ func (node *Node) String() string {
 }
 
 type BlankNodeGetter struct {
-	lastid int
+	lastid atomic.Int64
+}
+
+func (getter *BlankNodeGetter) set(i int) {
+	getter.lastid.Store(int64(i))
 }
 
 func (getter *BlankNodeGetter) Get() Node {
-	getter.lastid += 1
+	lastid := getter.lastid.Add(1)
 	return Node{
 		NodeType: BLANK,
-		ID:       fmt.Sprintf("N%v", getter.lastid),
+		ID:       fmt.Sprintf("N%v", lastid),
 	}
 }
 

--- a/rdfloader/parser/node_test.go
+++ b/rdfloader/parser/node_test.go
@@ -23,10 +23,10 @@ func TestBlankNodeGetter_Get(t *testing.T) {
 	}
 
 	// blank node getter with custom lastid.
-	blankNodeGetter = BlankNodeGetter{
-		lastid: -1,
-	}
+	blankNodeGetter = BlankNodeGetter{}
+
 	// last id -1 means that first node should start from N0
+	blankNodeGetter.set(-1)
 	firstBlankNode = blankNodeGetter.Get()
 	if firstBlankNode.ID != "N0" {
 		t.Errorf("Expected node to be %v, found %v", "N0", firstBlankNode.ID)

--- a/rdfwriter/utils.go
+++ b/rdfwriter/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/spdx/gordf/rdfloader/parser"
 	"github.com/spdx/gordf/uri"
+	"slices"
 	"strings"
 )
 
@@ -80,6 +81,16 @@ func getUniqueTriples(triples []*parser.Triple) []*parser.Triple {
 	for key := range set {
 		retList = append(retList, set[key])
 	}
+	slices.SortFunc(retList, func(a, b *parser.Triple) int {
+		c := strings.Compare(a.Subject.String(), b.Subject.String())
+		if c == 0 {
+			c = strings.Compare(a.Predicate.String(), b.Predicate.String())
+		}
+		if c == 0 {
+			c = strings.Compare(a.Object.String(), b.Predicate.String())
+		}
+		return c
+	})
 	return retList
 }
 

--- a/rdfwriter/utils_test.go
+++ b/rdfwriter/utils_test.go
@@ -136,6 +136,18 @@ func TestTopologicalSortTriples(t *testing.T) {
 		{Subject: nodes[0], Predicate: nodes[2], Object: nodes[3]},
 		{Subject: nodes[3], Predicate: nodes[4], Object: nodes[0]},
 	}
+	t.Logf("Got %d sortedTriples:", len(sortedTriples))
+	for k, v := range sortedTriples {
+			t.Logf("  sortedTriples[%v]=%s", k, v)
+	}
+	t.Logf("Want %d expectedTriples", len(expectedTriples))
+	for k, v := range expectedTriples {
+			t.Logf("  expectedTriples[%v]=%s", k, v)
+	}
+	t.Logf("Or %d anotherConfig", len(anotherConfig))
+	for k, v := range anotherConfig {
+			t.Logf("  anotherConfig[%v]=%s", k, v)
+	}
 	if !reflect.DeepEqual(sortedTriples, expectedTriples) && !reflect.DeepEqual(sortedTriples, anotherConfig) {
 		t.Errorf("sorted triples are not in correct order")
 	}


### PR DESCRIPTION
Use `sync/atomic` to synchronize the `Node.lastid` accesses, and the
existing `Parser.writeLock` to synchronize accesses to the deferenced
error pointer.

Introduce a package-private `Node.set` method to support initializing
`lastid` to different values.